### PR TITLE
Replace "reporing" for "reporting"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -157,7 +157,7 @@ jasperserver_tomcat_server_ajp_port: 8009
 jasperserver_tomcat_server_proxy_port: 8888
 
 # Reporting Abiquo
-abiquo_reporing_install_slave: yes
+abiquo_reporting_install_slave: yes
 abiquo_reporting_core_url: ''
 abiquo_reporting_core_file: 'abiquo-reporting-core.zip'
 abiquo_reporting_db_host: localhost

--- a/defaults/reporting.yml
+++ b/defaults/reporting.yml
@@ -1,2 +1,2 @@
 ---
-abiquo_reporing_ssl_jasperserver: no
+abiquo_reporting_ssl_jasperserver: no

--- a/tasks/reporting.yml
+++ b/tasks/reporting.yml
@@ -1,6 +1,6 @@
 ---
 - include_tasks: mariadb_slave.yml
-  when: abiquo_reporing_install_slave
+  when: abiquo_reporting_install_slave
 
 - include_tasks: jasper.yml
 

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -10,7 +10,7 @@
   <Service name="Catalina">
     <Connector port="{{ jasperserver_tomcat_server_port }}" URIEncoding="UTF-8" protocol="HTTP/1.1" connectionTimeout="20000" redirectPort="8443"/>
     <Connector port="{{ jasperserver_tomcat_server_ajp_port }}" protocol="AJP/1.3" redirectPort="8443"/>
-  {% if abiquo_reporing_ssl_jasperserver is defined and abiquo_reporing_ssl_jasperserver is sameas true %}
+  {% if abiquo_reporting_ssl_jasperserver is defined and abiquo_reporting_ssl_jasperserver is sameas true %}
   <Connector port="{{ jasperserver_tomcat_server_proxy_port }}" protocol="HTTP/1.1" connectionTimeout="20000" redirectPort="8443" URIEncoding="UTF-8" scheme="https" proxyPort="443"/>
   {% else %}
   <Connector port="{{ jasperserver_tomcat_server_proxy_port }}" protocol="HTTP/1.1" connectionTimeout="20000" URIEncoding="UTF-8" scheme="http"/>


### PR DESCRIPTION
Replaced "reporing" for "reporting" on:

- ansible-abiquo/tasks/reporting.yml:
when: abiquo_**reporing**_install_slave

- ansible-abiquo/defaults/reporting.yml:
abiquo_**reporing**_ssl_jasperserver: no

- ansible-abiquo/defaults/main.yml:
abiquo_**reporing**_install_slave: yes

- ansible-abiquo/templates/server.xml.j2:
{% if abiquo_**reporing**_ssl_jasperserver is defined and abiquo_**reporing**_ssl_jasperserver is sameas true %}